### PR TITLE
Poiting to public github url

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/davehorton/simple-sip-proxy#readme",
   "dependencies": {
     "debug": "*",
-    "drachtio": "git+ssh://git@github.com:davehorton/drachtio.git",
+    "drachtio": "https://github.com/davehorton/drachtio.git",
     "lodash": "~2.4.1",
     "range_check": "0.0.5"
   }  


### PR DESCRIPTION
This makes possible to properly run npm install without bothering about ssh keys and remote autenticity. Same has to be applied to dractio project.
